### PR TITLE
Make pipeline compatible with features input #51

### DIFF
--- a/annotation_agreement/README.md
+++ b/annotation_agreement/README.md
@@ -15,7 +15,7 @@ An example of such a file is given.
 In order to run the aggregation of annotations write the following command: 
 
 ```
-python3 aggregate_annotations.py -c class_number -a annotators -t type_of_aggregation -g gender -ml mean_low -mh mean_high -d deviation
+python3 aggregate_annotations.py -c class_number -a annotators -t type_of_aggregation -g gender -ml mean_low -mh mean_high -d deviation -ea exclude_annotators
 ``` 
 
 Where: 
@@ -27,7 +27,8 @@ Where:
 - gender: use 0 for male samples or 1 for female samples
 - mean_low: the threshold below which the mean value of the annotations must be obeyed in order for the sample to be considered as negative
 - mean_high: the threshold above which the mean value of the annotations must be obeyed in order for the sample to be considered as positive
-- deviation: the threshold below which the deviation of the annotations must be obeyed in order for the sample to be valid (not to be discarded)
+- deviation(optional) (default=0.75): the threshold below which the deviation of the annotations must be obeyed in order for the sample to be valid (not to be discarded)
+- exclude_annotatos(optional)(default=None): list of annotators' names (e.g. annotator1 annotator8) to be excluded from the proceedings due to their high value of average disagreement. Note: to use this argument it is recommended first to run the command once so as to observe the average disagreements of the annotators and consequently deside which of them to exclude.   
 
 ### results
 When running the above command, the following files will be produced: 

--- a/annotation_agreement/README.md
+++ b/annotation_agreement/README.md
@@ -15,7 +15,7 @@ An example of such a file is given.
 In order to run the aggregation of annotations write the following command: 
 
 ```
-python3 aggregate_annotations.py -c class_number -a annotators -t type_of_aggregation -g gender
+python3 aggregate_annotations.py -c class_number -a annotators -t type_of_aggregation -g gender -ml mean_low -mh mean_high -d deviation
 ``` 
 
 Where: 
@@ -25,6 +25,9 @@ Where:
 - annotators: an integer that defines the annotator's threshold. For example, if annotators = 3 then we take into account only the samples that are annotated by 3 or more annotators. 
 - type_of_aggregation: use 0 for majority vote or 1 for averaging
 - gender: use 0 for male samples or 1 for female samples
+- mean_low: the threshold below which the mean value of the annotations must be obeyed in order for the sample to be considered as negative
+- mean_high: the threshold above which the mean value of the annotations must be obeyed in order for the sample to be considered as positive
+- deviation: the threshold below which the deviation of the annotations must be obeyed in order for the sample to be valid (not to be discarded)
 
 ### results
 When running the above command, the following files will be produced: 

--- a/annotation_agreement/aggregate_annotations.py
+++ b/annotation_agreement/aggregate_annotations.py
@@ -16,7 +16,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import argparse
 
-def aggregate_annotations(file,class_number,type,gender,mean_low,mean_high,deviation=0.75):
+def aggregate_annotations(file, class_number, type, gender, mean_low, mean_high, deviation=0.75, exclude_annotator=None):
 
     data = pd.read_csv(file)
     
@@ -24,7 +24,11 @@ def aggregate_annotations(file,class_number,type,gender,mean_low,mean_high,devia
         data = data[data['Sample_name'].str.contains("_male")]
     elif gender == 1:
         data = data[data['Sample_name'].str.contains("_female")]
-    
+
+    if exclude_annotator != None:
+        for annotator in exclude_annotator:
+            data = data[data.Username != annotator]
+    #data = data[data.Username != 'apetrogianni@uth.gr']
     #data = data[data.Username != 'apetrogianni@uth.gr']
     #data = data[data.Username != 'Despina']
     #data = data[data.Username != 'kb@gmail.com']
@@ -129,7 +133,7 @@ def save_to_csv(df,name):
     df.to_csv(name, index=False)
 
 
-def report_annotations(file, class_number,annotators,type,gender,mean_low,mean_high,deviation=0.75):
+def report_annotations(file, class_number,annotators,type,gender,mean_low,mean_high,deviation=0.75,exclude_annotator=None):
 
     data = pd.read_csv(file)
     
@@ -141,13 +145,16 @@ def report_annotations(file, class_number,annotators,type,gender,mean_low,mean_h
         g = "female"
         print("-->Only female samples")
         data = data[data['Sample_name'].str.contains("_female")]
-    
+
+    if exclude_annotator != None:
+        for annotator in exclude_annotator:
+            data = data[data.Username != annotator]
     #data = data[data.Username != 'apetrogianni@uth.gr']
     #data = data[data.Username != 'Despina']
     #data = data[data.Username != 'kb@gmail.com']
     #data = data[data.Username != 'electrasif']
     #data = data[data.Username != 'rodo.kasidiari@gmail.com']
-    df = aggregate_annotations(file,class_number,type,gender,mean_low,mean_high,deviation)
+    df = aggregate_annotations(file,class_number,type,gender,mean_low,mean_high,deviation,exclude_annotator)
     csv_name = 'aggregate_annotations_of_class' + str(class_number) + g +'.csv'
     save_to_csv(df, csv_name)
 
@@ -421,5 +428,6 @@ if __name__ == "__main__":
                         help="High mean threshold")
     parser.add_argument("-d", "--deviation", type=float, required=False, default=0.75,
                         help="deviation threshold")
+    parser.add_argument("-ea", "--exclude_annotator", type=str, nargs='+', required=False, default=None, help="the annotators' names to be excluded the from the proceedings")
     args = parser.parse_args()
-    report_annotations('annotations_database_new.txt',args.class_number,args.annotators,args.type_of_aggregation,args.gender,args.mean_low,args.mean_high,args.deviation)
+    report_annotations('annotations_database_new.txt',args.class_number,args.annotators,args.type_of_aggregation,args.gender,args.mean_low,args.mean_high,args.deviation,args.exclude_annotator)

--- a/annotation_agreement/aggregate_annotations.py
+++ b/annotation_agreement/aggregate_annotations.py
@@ -430,4 +430,4 @@ if __name__ == "__main__":
                         help="deviation threshold")
     parser.add_argument("-ea", "--exclude_annotator", type=str, nargs='+', required=False, default=None, help="the annotators' names to be excluded the from the proceedings")
     args = parser.parse_args()
-    report_annotations('annotations_database_new.txt',args.class_number,args.annotators,args.type_of_aggregation,args.gender,args.mean_low,args.mean_high,args.deviation,args.exclude_annotator)
+    report_annotations('annotations_database.txt',args.class_number,args.annotators,args.type_of_aggregation,args.gender,args.mean_low,args.mean_high,args.deviation,args.exclude_annotator)

--- a/annotation_agreement/aggregate_annotations.py
+++ b/annotation_agreement/aggregate_annotations.py
@@ -16,14 +16,14 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import argparse
 
-def aggregate_annotations(file,class_number,type,gender):
+def aggregate_annotations(file,class_number,type,gender,mean_low,mean_high,deviation=0.75):
 
     data = pd.read_csv(file)
     
     if gender == 0:
-        data = data[data['Sample_name'].str.contains("_male_")]
+        data = data[data['Sample_name'].str.contains("_male")]
     elif gender == 1:
-        data = data[data['Sample_name'].str.contains("_female_")]
+        data = data[data['Sample_name'].str.contains("_female")]
     
     #data = data[data.Username != 'apetrogianni@uth.gr']
     #data = data[data.Username != 'Despina']
@@ -86,18 +86,18 @@ def aggregate_annotations(file,class_number,type,gender):
             sample_names.append(sample)
             mean.append(mean_value)
             dev.append(dev_value)
-            if mean_value <= 2.0:
+            if mean_value <= mean_low:
                 winner_without_dev.append("negative")
-            elif mean_value >= 3.2:
+            elif mean_value >= mean_high:
                 winner_without_dev.append("positive")
             else:
                 winner_without_dev.append("Nan")
 
-            if mean_value <= 2.0 and dev_value < 0.75:
+            if mean_value <= mean_low and dev_value < deviation:
                 winner.append("negative")
                 if len(sample_dataframe[class_name].values)>=3:
                     print(sample_dataframe[class_name].values," mean:",mean_value," σ:", dev_value, " class: negative")
-            elif mean_value >= 3.2 and dev_value < 0.75:
+            elif mean_value >= mean_high and dev_value < deviation:
                 winner.append("positive")
                 if len(sample_dataframe[class_name].values)>=3:
                     print(sample_dataframe[class_name].values," mean:",mean_value," σ:", dev_value, " class: positive")
@@ -129,25 +129,25 @@ def save_to_csv(df,name):
     df.to_csv(name, index=False)
 
 
-def report_annotations(file, class_number,annotators,type,gender):
+def report_annotations(file, class_number,annotators,type,gender,mean_low,mean_high,deviation=0.75):
 
     data = pd.read_csv(file)
     
     if gender == 0:
         g = "male"
         print("-->Only male samples")
-        data = data[data['Sample_name'].str.contains("_male_")]
+        data = data[data['Sample_name'].str.contains("_male")]
     elif gender == 1:
         g = "female"
         print("-->Only female samples")
-        data = data[data['Sample_name'].str.contains("_female_")]
+        data = data[data['Sample_name'].str.contains("_female")]
     
     #data = data[data.Username != 'apetrogianni@uth.gr']
     #data = data[data.Username != 'Despina']
     #data = data[data.Username != 'kb@gmail.com']
     #data = data[data.Username != 'electrasif']
     #data = data[data.Username != 'rodo.kasidiari@gmail.com']
-    df = aggregate_annotations(file,class_number,type,gender)
+    df = aggregate_annotations(file,class_number,type,gender,mean_low,mean_high,deviation)
     csv_name = 'aggregate_annotations_of_class' + str(class_number) + g +'.csv'
     save_to_csv(df, csv_name)
 
@@ -415,5 +415,11 @@ if __name__ == "__main__":
                         help="Choose between majority vote (0) or averaging (1)")
     parser.add_argument("-g", "--gender", type=int, required=True,
                         help="Choose between male (0) or female (1)")
+    parser.add_argument("-ml", "--mean_low", type=float, required=True,
+                        help="Low mean threshold")
+    parser.add_argument("-mh", "--mean_high", type=float, required=True,
+                        help="High mean threshold")
+    parser.add_argument("-d", "--deviation", type=float, required=False, default=0.75,
+                        help="deviation threshold")
     args = parser.parse_args()
-    report_annotations('annotations_database.txt',args.class_number,args.annotators,args.type_of_aggregation,args.gender)
+    report_annotations('annotations_database_new.txt',args.class_number,args.annotators,args.type_of_aggregation,args.gender,args.mean_low,args.mean_high,args.deviation)

--- a/models/readme.md
+++ b/models/readme.md
@@ -112,13 +112,13 @@ To train:
 10. Run training script e.g.  
 
 ```
-python3 train_recording_level_classifier.py -i speeches -mn speeches
+python3 train_recording_level_classifier.py -i speeches -mn speeches -f
 ``` 
 
 where the `-i` argument is the path to the folder that contains the folders 
 (one folder for each class, each one containing the respective recordings - 
 examples of each class). The model in the above example will be saved in 
-`output_models/recording_level/speeches.pt` or in case of late fusion two models will be saved: `output_models/recording_level/speeches_pyaudio.pt`, `output_models/recording_level/speeches_readys.pt`. 
+`output_models/recording_level/speeches.pt` or in case of late fusion two models will be saved: `output_models/recording_level/speeches_pyaudio.pt`, `output_models/recording_level/speeches_readys.pt`. The `-f` argument is optional and should be used only if the input files are extracted features and not audio. 
 
 
 ## 2.2 Testing
@@ -133,4 +133,4 @@ https://drive.google.com/drive/folders/1vuW93WZgb84Nt4iSjnuRTrEUfOUns4iV
 Test recording-level:
 1. Open the config file and define the google_credentials path and audio,
 text models paths as before. 
-2. Run `test_recording_level.py` e.g. `python3 test_recording_level.py -i test.wav -m output_models/recording_level/speeches.pt ` or in case of late fusion run: `python3 test_recording_level.py -i test.wav -m output_models/recording_level/speeches_readys.pt  -m2 output_models/recording_level/speeches_pyaudio.pt `
+2. Run `test_recording_level.py` e.g. `python3 test_recording_level.py -i test.wav -m output_models/recording_level/speeches.pt ` or in case of late fusion run: `python3 test_recording_level.py -i test.wav -m output_models/recording_level/speeches_MA.pt  -m2 output_models/recording_level/speeches_LLA.pt `

--- a/recording_level_analysis.py
+++ b/recording_level_analysis.py
@@ -1,6 +1,5 @@
 from models.test_recording_level import  predict_recording_level_label
 
-def get_final_class(audio_file,model_path):
-    class_name  = predict_recording_level_label(audio_file,model_path)
-    category = "Final recording level prediction"
-    return class_name,category
+def get_final_class(audio_file, model_path, model_path2=None):
+    class_name = predict_recording_level_label(audio_file, model_path, model_path2)
+    return class_name


### PR DESCRIPTION
This branch is responsible about making pipeline work for feature inputs (instead of audio input files). 

To test the changes together with the publicly available data, follow the below instructions: 

1. `git clone https://github.com/sofiaele/PuSQ.git`
2. Unzip the file: features_data.zip 
3. Put the contents of the repo (annotations_database.txt, dataset_parser.py, features_data) into the folder 'annotation_agreement' of the current repo. (Replace files if needed). 
4. `python3 aggregate_annotations.py -c 1 -a 3 -t 1 -g 1 -mh 4.0 -ml 2.0 -ea annotator8` 
to aggregate annotations for class 1 (expressive), minimum number of annotators = 3, type of aggregation = averaging, gender = female, low mean threshold = 2.0, high mean threshold = 4.0, exclude annotator8 (because of his high average disagreement for the specific task)
5. `python3 dataset_parser.py -n expressive_female -aa aggregated_Class1female.csv -i features_data`, to parse the data into class folders 
6. `python3 models/train_recording_level_classifier.py -i annotation_agreement/datasets/expressive_female/ -mn test_model -f` to train recording-level classifier with the previous parsed data (note: the specs of this classifier are defined in the 'models/config.yaml'. You can keep them as they are. 
7. `python3 models/test_recording_level.py -i annotation_agreement/datasets/expressive_female/negative/1_speaker27_female_MetaAudio.npz -m models/output_models/recording_level/test_model_MA.pt -m2 models/output_models/recording_level/test_model_LLA.pt`, to test input 1_speaker27_female (predict class). 


